### PR TITLE
dependabot: build(deps-dev): bump the npm-development group across 1 directory wi…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15213,9 +15213,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",


### PR DESCRIPTION
…th 12 updates

Bumps the npm-development group with 11 updates in the / directory:

| Package | From | To |
| --- | --- | --- |
| [@eslint/js](https://github.com/eslint/eslint/tree/HEAD/packages/js) | `9.30.0` | `9.32.0` | | [@types/node](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/HEAD/types/node) | `22.15.34` | `22.17.0` | | [@typescript-eslint/eslint-plugin](https://github.com/typescript-eslint/typescript-eslint/tree/HEAD/packages/eslint-plugin) | `8.35.0` | `8.38.0` | | [conventional-changelog-conventionalcommits](https://github.com/conventional-changelog/conventional-changelog/tree/HEAD/packages/conventional-changelog-conventionalcommits) | `9.0.0` | `9.1.0` | | [eslint](https://github.com/eslint/eslint) | `9.30.0` | `9.32.0` | | [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier) | `10.1.5` | `10.1.8` | | [eslint-plugin-prettier](https://github.com/prettier/eslint-plugin-prettier) | `5.5.1` | `5.5.3` | | [lint-staged](https://github.com/lint-staged/lint-staged) | `16.1.2` | `16.1.4` | | [npm-check-updates](https://github.com/raineorshine/npm-check-updates) | `18.0.1` | `18.0.2` | | [semantic-release](https://github.com/semantic-release/semantic-release) | `24.2.6` | `24.2.7` | | [typescript](https://github.com/microsoft/TypeScript) | `5.8.3` | `5.9.2` |



Updates `@eslint/js` from 9.30.0 to 9.32.0
- [Release notes](https://github.com/eslint/eslint/releases)
- [Changelog](https://github.com/eslint/eslint/blob/main/CHANGELOG.md)
- [Commits](https://github.com/eslint/eslint/commits/v9.32.0/packages/js)

Updates `@types/node` from 22.15.34 to 22.17.0
- [Release notes](https://github.com/DefinitelyTyped/DefinitelyTyped/releases)
- [Commits](https://github.com/DefinitelyTyped/DefinitelyTyped/commits/HEAD/types/node)

Updates `@typescript-eslint/eslint-plugin` from 8.35.0 to 8.38.0
- [Release notes](https://github.com/typescript-eslint/typescript-eslint/releases)
- [Changelog](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/CHANGELOG.md)
- [Commits](https://github.com/typescript-eslint/typescript-eslint/commits/v8.38.0/packages/eslint-plugin)

Updates `@typescript-eslint/parser` from 8.35.0 to 8.38.0
- [Release notes](https://github.com/typescript-eslint/typescript-eslint/releases)
- [Changelog](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/parser/CHANGELOG.md)
- [Commits](https://github.com/typescript-eslint/typescript-eslint/commits/v8.38.0/packages/parser)

Updates `conventional-changelog-conventionalcommits` from 9.0.0 to 9.1.0
- [Release notes](https://github.com/conventional-changelog/conventional-changelog/releases)
- [Changelog](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-conventionalcommits/CHANGELOG.md)
- [Commits](https://github.com/conventional-changelog/conventional-changelog/commits/conventional-changelog-conventionalcommits-v9.1.0/packages/conventional-changelog-conventionalcommits)

Updates `eslint` from 9.30.0 to 9.32.0
- [Release notes](https://github.com/eslint/eslint/releases)
- [Changelog](https://github.com/eslint/eslint/blob/main/CHANGELOG.md)
- [Commits](https://github.com/eslint/eslint/compare/v9.30.0...v9.32.0)

Updates `eslint-config-prettier` from 10.1.5 to 10.1.8
- [Release notes](https://github.com/prettier/eslint-config-prettier/releases)
- [Changelog](https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md)
- [Commits](https://github.com/prettier/eslint-config-prettier/compare/v10.1.5...v10.1.8)

Updates `eslint-plugin-prettier` from 5.5.1 to 5.5.3
- [Release notes](https://github.com/prettier/eslint-plugin-prettier/releases)
- [Changelog](https://github.com/prettier/eslint-plugin-prettier/blob/main/CHANGELOG.md)
- [Commits](https://github.com/prettier/eslint-plugin-prettier/compare/v5.5.1...v5.5.3)

Updates `lint-staged` from 16.1.2 to 16.1.4
- [Release notes](https://github.com/lint-staged/lint-staged/releases)
- [Changelog](https://github.com/lint-staged/lint-staged/blob/main/CHANGELOG.md)
- [Commits](https://github.com/lint-staged/lint-staged/compare/v16.1.2...v16.1.4)

Updates `npm-check-updates` from 18.0.1 to 18.0.2
- [Release notes](https://github.com/raineorshine/npm-check-updates/releases)
- [Changelog](https://github.com/raineorshine/npm-check-updates/blob/main/CHANGELOG.md)
- [Commits](https://github.com/raineorshine/npm-check-updates/compare/v18.0.1...v18.0.2)

Updates `semantic-release` from 24.2.6 to 24.2.7
- [Release notes](https://github.com/semantic-release/semantic-release/releases)
- [Commits](https://github.com/semantic-release/semantic-release/compare/v24.2.6...v24.2.7)

Updates `typescript` from 5.8.3 to 5.9.2
- [Release notes](https://github.com/microsoft/TypeScript/releases)
- [Changelog](https://github.com/microsoft/TypeScript/blob/main/azure-pipelines.release-publish.yml)
- [Commits](https://github.com/microsoft/TypeScript/compare/v5.8.3...v5.9.2)

---
updated-dependencies:
- dependency-name: "@eslint/js" dependency-version: 9.32.0 dependency-type: direct:development update-type: version-update:semver-minor dependency-group: npm-development
- dependency-name: "@types/node" dependency-version: 22.17.0 dependency-type: direct:development update-type: version-update:semver-minor dependency-group: npm-development
- dependency-name: "@typescript-eslint/eslint-plugin" dependency-version: 8.38.0 dependency-type: direct:development update-type: version-update:semver-minor dependency-group: npm-development
- dependency-name: "@typescript-eslint/parser" dependency-version: 8.38.0 dependency-type: direct:development update-type: version-update:semver-minor dependency-group: npm-development
- dependency-name: conventional-changelog-conventionalcommits dependency-version: 9.1.0 dependency-type: direct:development update-type: version-update:semver-minor dependency-group: npm-development
- dependency-name: eslint dependency-version: 9.32.0 dependency-type: direct:development update-type: version-update:semver-minor dependency-group: npm-development
- dependency-name: eslint-config-prettier dependency-version: 10.1.8 dependency-type: direct:development update-type: version-update:semver-patch dependency-group: npm-development
- dependency-name: eslint-plugin-prettier dependency-version: 5.5.3 dependency-type: direct:development update-type: version-update:semver-patch dependency-group: npm-development
- dependency-name: lint-staged dependency-version: 16.1.4 dependency-type: direct:development update-type: version-update:semver-patch dependency-group: npm-development
- dependency-name: npm-check-updates dependency-version: 18.0.2 dependency-type: direct:development update-type: version-update:semver-patch dependency-group: npm-development
- dependency-name: semantic-release dependency-version: 24.2.7 dependency-type: direct:development update-type: version-update:semver-patch dependency-group: npm-development
- dependency-name: typescript dependency-version: 5.9.2 dependency-type: direct:development update-type: version-update:semver-minor dependency-group: npm-development ...