### PR TITLE
fix: moveCursor not a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ ssdx create -n my_feature
 - `-v, --target-dev-hub <string>:` The alias or username of the dev hub org.
 - `--skip-dependencies:` Skip dependency installation.
 - `--skip-deployment:` Skip the deployment step.
+- `--ci:` Disable fancy output for CI environments.
+- `--disable-notifications:` Disable OS notifications (useful for CI environments)
 
 ## resource
 
@@ -71,6 +73,7 @@ ssdx resource [options]
 - `--show-output:` Show output of resource assignments.
 - `-l, --test-level <string>:` Specify the test level for metadata operations (default: NoTestRun).
 - `--ci:` Disable fancy output for CI environments.
+- `--disable-notifications:` Disable OS notifications (useful for CI environments)
 
 # Configuration
 

--- a/src/cli/create/steps/dependencies.ts
+++ b/src/cli/create/steps/dependencies.ts
@@ -44,7 +44,7 @@ class Dependencies {
         '--targetdevhubusername',
         CreateOptions.targetDevHub,
       ],
-      outputType: OutputType.OutputLiveAndClear,
+      outputType: CreateOptions.ci ? OutputType.OutputLiveWithHeader : OutputType.OutputLiveAndClear,
     });
 
     const spinner = ora('Installed Dependencies Successfully').start();

--- a/src/lib/command-helper.ts
+++ b/src/lib/command-helper.ts
@@ -237,8 +237,12 @@ export interface CmdResult {
 }
 
 function clearNLines(N: number): void {
-  process.stdout.moveCursor(0, -N);
-  process.stdout.clearScreenDown();
+  try {
+    process.stdout.moveCursor(0, -N);
+    process.stdout.clearScreenDown();
+  } catch (error) {
+    logger.error(error);
+  }
 }
 
 // TODO: move to new method


### PR DESCRIPTION
handle error in github actions "process.stdout.moveCursor is not a function" when creating scratch org